### PR TITLE
List the approved and ready tasks of a given workflow request in multi step approval processes

### DIFF
--- a/components/org.wso2.carbon.identity.workflow.engine/src/main/java/org/wso2/carbon/identity/workflow/engine/util/WorkflowEngineConstants.java
+++ b/components/org.wso2.carbon.identity.workflow.engine/src/main/java/org/wso2/carbon/identity/workflow/engine/util/WorkflowEngineConstants.java
@@ -126,15 +126,21 @@ public class WorkflowEngineConstants {
      * Represents the possible statuses of an approval task.
      */
     public enum TaskStatus {
+
+        /** Task is ready to be assigned and worked on */
         READY,
+
+        /** The Task has been reserved/claimed by an approver but not yet completed */
         RESERVED,
-        COMPLETED,
+
+        /** The Task has been approved by the assigned approver */
+        APPROVED,
+
+        /** Task is blocked and cannot proceed */
         BLOCKED,
+
+        /** The Task has been rejected by the assigned approver */
         REJECTED;
-
-        TaskStatus() {
-
-        }
     }
 
     /**


### PR DESCRIPTION
## Purpose
For multi step approval tasks, when the first step is approved, and the second step has to be approved by the same user (Ideally shouldn't happen), as the same workflow request is corresponds to both approval tasks, only one (first approved task) will be shown where the next ready approval task is not filtered when filter without status. 
If filter by ready state, the ready state approval task will be shown. 

The above mentioned case is fixed by this PR.