### PR TITLE
Handle internal server error when role does not exist in approval request

### DIFF
--- a/components/org.wso2.carbon.identity.workflow.engine/src/main/java/org/wso2/carbon/identity/workflow/engine/ApprovalTaskServiceImpl.java
+++ b/components/org.wso2.carbon.identity.workflow.engine/src/main/java/org/wso2/carbon/identity/workflow/engine/ApprovalTaskServiceImpl.java
@@ -102,6 +102,7 @@ public class ApprovalTaskServiceImpl implements ApprovalTaskService {
     private static final String TENANT_DOMAIN_PARAM_NAME = "Tenant Domain";
     private static final String AUDIENCE_ID_PARAM_NAME = "Audience ID";
     private static final String COMMA_SEPARATOR = ",";
+    private static final String ROLE_NOT_FOUND_ERROR_CODE = "RMA-60007";
 
     @Override
     public List<ApprovalTaskSummaryDTO> listApprovalTasks(Integer limit, Integer offset, List<String> statusList)
@@ -533,7 +534,11 @@ public class ApprovalTaskServiceImpl implements ApprovalTaskService {
                             workflowRequestProperties.add(propertyDTO);
                         }
                     } catch (IdentityRoleManagementException e) {
-                        throw new WorkflowEngineException(e.getMessage(), e);
+                        if (StringUtils.equals(ROLE_NOT_FOUND_ERROR_CODE, e.getErrorCode())) {
+                            valueString = StringUtils.EMPTY;
+                        } else {
+                            throw new WorkflowEngineException(e.getMessage(), e);
+                        }
                     }
                 } else if (USERS_TO_BE_ADDED_PARAM_NAME.equals(paramString)
                         || USERS_TO_BE_DELETED_PARAM_NAME.equals(paramString)) {
@@ -546,6 +551,8 @@ public class ApprovalTaskServiceImpl implements ApprovalTaskService {
                             List<String> userNames = userStoreManager.getUserNamesFromUserIDs((List<String>) value);
                             if (CollectionUtils.isNotEmpty(userNames)) {
                                 valueString = String.join(COMMA_SEPARATOR, userNames);
+                            } else {
+                                valueString = StringUtils.EMPTY;
                             }
                         }
                     } catch (UserStoreException e) {


### PR DESCRIPTION
## Purpose

**Error handling improvements:**

* Added a specific check for the role not found error (`RMA-60007`). If this error occurs during role lookup, the value is set to an empty string instead of throwing an exception. [[1]](diffhunk://#diff-390c1f9dfa912a153df836f9f038a40d7dab970d6386f60ecf4a98595a53a499R105) [[2]](diffhunk://#diff-390c1f9dfa912a153df836f9f038a40d7dab970d6386f60ecf4a98595a53a499R537-R542)

**Data consistency improvements:**

* When looking up user names from user IDs, if no user names are found, the value is now set to an empty string to ensure consistent parameter formatting.