### PR TITLE
Implement group-based approvers functionality

### DIFF
--- a/components/org.wso2.carbon.identity.workflow.engine/src/main/java/org/wso2/carbon/identity/workflow/engine/ApprovalTaskServiceImpl.java
+++ b/components/org.wso2.carbon.identity.workflow.engine/src/main/java/org/wso2/carbon/identity/workflow/engine/ApprovalTaskServiceImpl.java
@@ -74,6 +74,8 @@ import org.wso2.carbon.identity.workflow.mgt.exception.WorkflowException;
 import org.wso2.carbon.identity.workflow.mgt.util.WorkflowDataType;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
+import org.wso2.carbon.user.core.common.Group;
+import org.wso2.carbon.user.core.common.User;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -487,6 +489,24 @@ public class ApprovalTaskServiceImpl implements ApprovalTaskService {
             } else {
                 approversToNotify.addAll(roleMembers);
             }
+        } else if (WorkflowEngineConstants.APPROVER_TYPE_GROUPS.equalsIgnoreCase(approverType)) {
+            List<String> groupMembers = new ArrayList<>();
+            try {
+                groupMembers = getUserIdsAssignedToGroup(approverIdentifier, tenantDomain);
+            } catch (WorkflowEngineException e) {
+                log.error("Error while retrieving assigned user IDs for group: {} in tenant: {}. " +
+                                "Continuing without adding notifications for this group.",
+                        approverIdentifier, tenantDomain, e);
+            }
+            if (CollectionUtils.isEmpty(groupMembers)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Group approver '{}' in tenant '{}' has no assigned users. " +
+                                    "No notifications will be sent for this group.",
+                            approverIdentifier, tenantDomain);
+                }
+            } else {
+                approversToNotify.addAll(groupMembers);
+            }
         } else {
             approversToNotify.add(approverIdentifier);
         }
@@ -727,8 +747,9 @@ public class ApprovalTaskServiceImpl implements ApprovalTaskService {
 
                 // Retrieving the tenant domain of the user corresponding to the userId to validate reserved task users.
                 String tenantDomain = CarbonContext.getThreadLocalCarbonContext().getTenantDomain();
-                // Get the user's roles.
+                // Get the user's roles and groups.
                 List<String> entityIds = getAssignedRoleIds(userId, tenantDomain);
+                entityIds.addAll(getAssignedGroupIds(userId, tenantDomain));
                 // Add userId as eligible entity if the workflow has USER.
                 entityIds.add(userId);
 
@@ -779,6 +800,8 @@ public class ApprovalTaskServiceImpl implements ApprovalTaskService {
 
         List<String> roleIds = getAssignedRoleIds(userId, tenantDomain);
         entityIds.addAll(roleIds);
+        List<String> groupIds = getAssignedGroupIds(userId, tenantDomain);
+        entityIds.addAll(groupIds);
         int tenantId = CarbonContext.getThreadLocalCarbonContext().getTenantId();
         return approvalTaskDAO.getFilteredApprovalTaskDetails(entityIds, filter, limit, offset, tenantId);
     }
@@ -890,6 +913,36 @@ public class ApprovalTaskServiceImpl implements ApprovalTaskService {
         }
     }
 
+    private List<String> getAssignedGroupIds(String userId, String tenantDomain) throws WorkflowEngineException {
+
+        try {
+            int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
+            AbstractUserStoreManager userStoreManager = (AbstractUserStoreManager)
+                    WorkflowEngineServiceDataHolder.getInstance()
+                            .getRealmService().getTenantUserRealm(tenantId).getUserStoreManager();
+            List<Group> groups = userStoreManager.getGroupListOfUser(userId, -1, 0, null, null);
+            return groups.stream().map(Group::getGroupID).collect(Collectors.toList());
+        } catch (UserStoreException e) {
+            throw new WorkflowEngineException(
+                    WorkflowEngineConstants.ErrorMessages
+                            .ERROR_OCCURRED_WHILE_RETRIEVING_APPROVAL_TASKS_FOR_USER.getDescription(), e);
+        }
+    }
+
+    private List<String> getUserIdsAssignedToGroup(String groupId, String tenantDomain) throws WorkflowEngineException {
+
+        try {
+            int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
+            AbstractUserStoreManager userStoreManager = (AbstractUserStoreManager)
+                    WorkflowEngineServiceDataHolder.getInstance()
+                            .getRealmService().getTenantUserRealm(tenantId).getUserStoreManager();
+            List<User> users = userStoreManager.getUserListOfGroup(groupId, -1, 0, null, null);
+            return users.stream().map(User::getUserID).collect(Collectors.toList());
+        } catch (UserStoreException e) {
+            throw new WorkflowEngineException("Error occurred while retrieving users assigned to group.", e);
+        }
+    }
+
     private void validateApprovers(String taskId) throws WorkflowEngineException {
 
         String userId = Utils.resolveUserID(CarbonContext.getThreadLocalCarbonContext().getUserId());
@@ -900,6 +953,11 @@ public class ApprovalTaskServiceImpl implements ApprovalTaskService {
         if (ENTITY_TYPE_USERS.equals(approverDTO.getApproverType()) ||
                 ENTITY_TYPE_CLAIMED_USERS.equals(approverDTO.getApproverType())) {
             if (approverDTO.getApproverName().equals(userId)) {
+                isAssignedApprovalTask = true;
+            }
+        } else if (WorkflowEngineConstants.APPROVER_TYPE_GROUPS.equals(approverDTO.getApproverType())) {
+            List<String> groupIds = getAssignedGroupIds(userId, tenantDomain);
+            if (groupIds.contains(approverDTO.getApproverName())) {
                 isAssignedApprovalTask = true;
             }
         } else {
@@ -1060,7 +1118,8 @@ public class ApprovalTaskServiceImpl implements ApprovalTaskService {
                             .workflowId(workflowId)
                             .newStatus(reservedStatus);
                     auditLogger.printAuditLog(auditBuilder);
-                } else if (WorkflowEngineConstants.APPROVER_TYPE_ROLES.equals(approverType)) {
+                } else if (WorkflowEngineConstants.APPROVER_TYPE_ROLES.equals(approverType) ||
+                        WorkflowEngineConstants.APPROVER_TYPE_GROUPS.equals(approverType)) {
                     // Create a new task for the user who claimed the task.
                     String newTaskId = UUID.randomUUID().toString();
                     approvalTaskDAO.addApproversOfRequest(newTaskId, workflowRequestID, workflowId,

--- a/components/org.wso2.carbon.identity.workflow.engine/src/main/java/org/wso2/carbon/identity/workflow/engine/util/WorkflowEngineConstants.java
+++ b/components/org.wso2.carbon.identity.workflow.engine/src/main/java/org/wso2/carbon/identity/workflow/engine/util/WorkflowEngineConstants.java
@@ -35,6 +35,7 @@ public class WorkflowEngineConstants {
     public static final String RELATIONSHIP_ID_IN_REQUEST_COLUMN = "RELATIONSHIP_ID";
     public static final String APPROVER_TYPE_USERS = "users";
     public static final String APPROVER_TYPE_ROLES = "roles";
+    public static final String APPROVER_TYPE_GROUPS = "groups";
     public static final String REQUEST_ID_COLUMN = "REQUEST_ID";
     public static final int NO_CURRENT_STEP = -1;
     public static final String Q_NAME_STEP_SEPARATOR = "-";
@@ -144,6 +145,7 @@ public class WorkflowEngineConstants {
         public static final String ENTITY_TYPE_ROLES = "roles";
         public static final String ENTITY_TYPE_USERS = "users";
         public static final String ENTITY_TYPE_CLAIMED_USERS = "claimedUsers";
+        public static final String ENTITY_TYPE_GROUPS = "groups";
         public static final String CLAIMS_PROPERTY_NAME = "Claims";
     }
 


### PR DESCRIPTION
## Purpose
> 
This pull request adds support for group-based approvers in the workflow engine, allowing approval tasks to be assigned and validated for user groups in addition to individual users and roles. The main changes include updating the logic for collecting approvers, validating assigned tasks, and handling claims to incorporate groups, as well as introducing utility methods for group membership resolution.

**Support for group-based approvers:**

* Added a new approver type constant `APPROVER_TYPE_GROUPS` and entity type constant `ENTITY_TYPE_GROUPS` in `WorkflowEngineConstants`, enabling the identification and handling of group approvers. [[1]](diffhunk://#diff-101652ca28430fddc1ebad7fb443b6ed3567d3857d035db7215b1f6688061115R38) [[2]](diffhunk://#diff-101652ca28430fddc1ebad7fb443b6ed3567d3857d035db7215b1f6688061115R148)
* Updated the approver collection logic in `collectApproversForNotification` to retrieve and notify all users assigned to a group approver.
* Enhanced task assignment and filtering logic to include groups a user is a member of, ensuring group-based tasks are correctly retrieved and displayed for users. [[1]](diffhunk://#diff-390c1f9dfa912a153df836f9f038a40d7dab970d6386f60ecf4a98595a53a499L730-R752) [[2]](diffhunk://#diff-390c1f9dfa912a153df836f9f038a40d7dab970d6386f60ecf4a98595a53a499R803-R804)
* Modified approver validation and claim handling to support group-based assignments, ensuring users in a group can claim and validate tasks assigned to their group. [[1]](diffhunk://#diff-390c1f9dfa912a153df836f9f038a40d7dab970d6386f60ecf4a98595a53a499R958-R962) [[2]](diffhunk://#diff-390c1f9dfa912a153df836f9f038a40d7dab970d6386f60ecf4a98595a53a499L1063-R1122)

**Utility methods for group membership:**

* Added `getAssignedGroupIds` and `getUserIdsAssignedToGroup` methods to resolve group memberships and group members, used throughout the approval logic.

These changes collectively enable workflows to assign, notify, and validate approval tasks for user groups, improving flexibility and coverage in workflow assignments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow approvers can now be assigned based on user groups
  * Group members are automatically expanded for approval notifications and task assignments
  * Approval task filtering now includes group-based approvers in results

<!-- end of auto-generated comment: release notes by coderabbit.ai -->